### PR TITLE
Add pip version of typing-extensions package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10676,6 +10676,10 @@ python3-typing-extensions:
     bionic:
       pip:
         packages: [typing-extensions]
+python3-typing-extensions-pip:
+  '*':
+    pip:
+      packages: [typing-extensions]
 python3-tz:
   alpine: [py3-tz]
   arch: [python-pytz]


### PR DESCRIPTION
###
- Added Python pip version of typing-extensions package to rosdep/python.yaml